### PR TITLE
tiny_id_info 表的id应该用bigint,  而不需要带unsigned.

### DIFF
--- a/tinyid-server/db.sql
+++ b/tinyid-server/db.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `tiny_id_info` (
-  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '自增主键',
+  `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT '自增主键',
   `biz_type` varchar(63) NOT NULL DEFAULT '' COMMENT '业务类型，唯一',
   `begin_id` bigint(20) NOT NULL DEFAULT '0' COMMENT '开始id，仅记录初始值，无其他含义。初始化时begin_id和max_id应相同',
   `max_id` bigint(20) NOT NULL DEFAULT '0' COMMENT '当前最大id',


### PR DESCRIPTION
`id` bigint(20) unsigned id字段为无符号时，在Javabean对应的应该是 BigInteger.
对应是Long时，会有越界问题。9223372036854775808在bigint(20) unsigned可以保存，但赋值给Long会越界。
建议使用ORM框架Bee的GenBean自动生成Javabean.
鉴于tiny_id_info表不会有太多的记录，用bigint(20)就可以了。